### PR TITLE
Kirkstone Upgrade

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_meta-azure-device-update-diffs = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-azure-device-update-diffs = "15"
 
 LAYERDEPENDS_meta-azure-device-update-diffs = "core"
-LAYERSERIES_COMPAT_meta-azure-device-update-diffs = "honister"
+LAYERSERIES_COMPAT_meta-azure-device-update-diffs = "honister kirkstone"
 
 BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.%s' % (layer, ext) \
                for layer in '${BBFILE_COLLECTIONS}'.split() for ext in ['bb', 'bbappend'])}"

--- a/recipes-azure-device-update-diffs/azure-device-update-diffs/azure-device-update-diffs_git.bb
+++ b/recipes-azure-device-update-diffs/azure-device-update-diffs/azure-device-update-diffs_git.bb
@@ -4,8 +4,8 @@ LICENSE = "CLOSED"
 
 ADU_DELTA_GIT_BRANCH ?= "main"
 
-ADU_DELTA_SRC_URI ?= "gitsm://github.com/azure/io-thub-device-update-delta"
-SRC_URI = "${ADU_DELTA_SRC_URI};branch=${ADU_DELTA_GIT_BRANCH} \
+ADU_DELTA_SRC_URI ?= "git://github.com/azure/iot-hub-device-update-delta.git"
+SRC_URI = "${ADU_DELTA_SRC_URI};protocol=https;branch=${ADU_DELTA_GIT_BRANCH} \
           file://0001-ADU-v1.0.0-Yocto-mininum-build.patch \
           file://0002-Add-root-CMakeLists.txt.patch \
           file://0003-Fix-io_utility-CMakeLists.txt.patch \

--- a/recipes-bsdiff/bsdiff/bsdiff_git.bb
+++ b/recipes-bsdiff/bsdiff/bsdiff_git.bb
@@ -8,7 +8,7 @@ LICENSE = "bsdiff"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f83b6905339a1462b8b70a6d742af235"
 
 
-# SRC_URI = "gitsm://github.com/microsoft/do-client;branch=main"
+# SRC_URI = "git://github.com/microsoft/do-client;protocol=https;branch=main"
 # SRCREV = "ef70c5c8a59d46820c648f434249516957966e7f"
 # PV = "1.0+git${SRCPV}"
 # S = "${WORKDIR}/git" 

--- a/recipes-ms-gsl/ms-gsl/ms-gsl_git.bb
+++ b/recipes-ms-gsl/ms-gsl/ms-gsl_git.bb
@@ -7,7 +7,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=363055e71e77071107ba2bb9a54bd9a7"
 
 # We snap to public-preview-pnp for the latest and greates pnp changes.
-SRC_URI = "gitsm://github.com/microsoft/GSL.git;branch=main"
+SRC_URI = "git://github.com/microsoft/GSL.git;protocol=https;branch=main"
 
 # ADU Diff library requires tag v4.0.0
 SRCREV = "a3534567187d2edc428efd3f13466ff75fe5805c"


### PR DESCRIPTION
Hello!  I've updated this layer to support Yocto+Kirkstone (to go alongside my meta-iotedge Kirkstone upgrade @ https://github.com/Azure/meta-iotedge/pull/107)

I did not explicitly test any delta update mechanisms, but I can confirm the layer now compiles fine under Kirkstone.

If you would like to open a separate Kirkstone branch, I would be happy to reopen this pull request on top of that branch as well.