### PR TITLE
Fix missing header file - solve undefined 'uint64_t' errors.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_meta-azure-device-update-diffs = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-azure-device-update-diffs = "15"
 
 LAYERDEPENDS_meta-azure-device-update-diffs = "core"
-LAYERSERIES_COMPAT_meta-azure-device-update-diffs = "honister"
+LAYERSERIES_COMPAT_meta-azure-device-update-diffs = "honister scarthgap"
 
 BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.%s' % (layer, ext) \
                for layer in '${BBFILE_COLLECTIONS}'.split() for ext in ['bb', 'bbappend'])}"

--- a/recipes-azure-device-update-diffs/azure-device-update-diffs/azure-device-update-diffs_git.bb
+++ b/recipes-azure-device-update-diffs/azure-device-update-diffs/azure-device-update-diffs_git.bb
@@ -4,12 +4,13 @@ LICENSE = "CLOSED"
 
 ADU_DELTA_GIT_BRANCH ?= "main"
 
-ADU_DELTA_SRC_URI ?= "gitsm://github.com/azure/io-thub-device-update-delta"
+ADU_DELTA_SRC_URI ?= "gitsm://github.com/azure/iot-hub-device-update-delta"
 SRC_URI = "${ADU_DELTA_SRC_URI};branch=${ADU_DELTA_GIT_BRANCH} \
           file://0001-ADU-v1.0.0-Yocto-mininum-build.patch \
           file://0002-Add-root-CMakeLists.txt.patch \
           file://0003-Fix-io_utility-CMakeLists.txt.patch \
           file://0004-Add-missing-header-in-zstd_decompression_reader.patch \
+          file://0005-Add-missing-header-for-uint64_t.patch \
           "
 
 ADU_DELTA_GIT_COMMIT ?= "b581e92458f458969b427051a2ac5d18d3528dc6"

--- a/recipes-azure-device-update-diffs/azure-device-update-diffs/files/0005-Add-missing-header-for-uint64_t.patch
+++ b/recipes-azure-device-update-diffs/azure-device-update-diffs/files/0005-Add-missing-header-for-uint64_t.patch
@@ -1,0 +1,38 @@
+From 42365375c543c4b79534e3accfe5b378ccc0fc08 Mon Sep 17 00:00:00 2001
+From: nox-msft <wewilair@microsoft.com>
+Date: Tue, 2 Jul 2024 05:20:42 +0000
+Subject: [PATCH] Add missing header for uint64_t
+
+---
+ src/diffs/api/adudiffcreate.h  | 2 +-
+ src/diffs/api/create_session.h | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/diffs/api/adudiffcreate.h b/src/diffs/api/adudiffcreate.h
+index 4b54c01..31f3d59 100644
+--- a/src/diffs/api/adudiffcreate.h
++++ b/src/diffs/api/adudiffcreate.h
+@@ -7,7 +7,7 @@
+ #pragma once
+ 
+ #include "adudiffapi.h"
+-
++#include "stdint.h"
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff --git a/src/diffs/api/create_session.h b/src/diffs/api/create_session.h
+index 7dd4d68..fc19ae4 100644
+--- a/src/diffs/api/create_session.h
++++ b/src/diffs/api/create_session.h
+@@ -7,6 +7,7 @@
+ #pragma once
+ 
+ #include <string>
++#include <stdint.h>
+ #include <vector>
+ 
+ #include "adudiffcreate.h"
+-- 
+2.34.1
+

--- a/recipes-bsdiff/LICENSE
+++ b/recipes-bsdiff/LICENSE
@@ -1,0 +1,24 @@
+ Copyright 2003-2005 Colin Percival
+ Copyright 2021 zhuyie
+ All rights reserved
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted providing that the following conditions 
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.

--- a/recipes-bsdiff/bsdiff/bsdiff_git.bb
+++ b/recipes-bsdiff/bsdiff/bsdiff_git.bb
@@ -4,7 +4,7 @@ DESCRIPTION = "BSDiff"
 AUTHOR = "zhuyie, Colin Percival"
 HOMEPAGE = "https://github.com/zhuyie/bsdiff"
 
-LICENSE = "bsdiff"
+LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f83b6905339a1462b8b70a6d742af235"
 
 


### PR DESCRIPTION
- Include "stdint.h" which fixing 'undefined uint64_t' errors
- Update bsdiff license info (temporary) to unblock the build.